### PR TITLE
docs: add missing remotion bundler import in tailwind

### DIFF
--- a/packages/docs/docs/resources.md
+++ b/packages/docs/docs/resources.md
@@ -58,7 +58,7 @@ This list tries to compile all templates, libraries, building blocks and example
 - [Product Hunt Today](https://github.com/Kamigami55/product-hunt-today)
 - [Remotion Weather](https://github.com/florentpergoud/remotion-weather)
 - [Rewind Table](https://github.com/gregonarash/rewind-table) _(Airtable templates for Remotion)_
-
+- [Conference Speaker Announcement Cards](https://github.com/lyonjs/social-video-generator)
 ## Examples
 
 - [Music with Tone.JS](https://github.com/remotion-dev/tone-js-example)

--- a/packages/docs/docs/tailwind.md
+++ b/packages/docs/docs/tailwind.md
@@ -60,7 +60,7 @@ values={[
 <TabItem value="npm">
 
 ```bash
-npm i -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
+npm i -D @remotion/bundler postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>
@@ -68,14 +68,14 @@ npm i -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-
   <TabItem value="yarn">
 
 ```bash
-yarn add -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
+yarn add -D @remotion/bundler postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>
   <TabItem value="pnpm">
 
 ```bash
-pnpm i -D postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
+pnpm i -D @remotion/bundler postcss-loader postcss postcss-preset-env tailwindcss autoprefixer css-loader style-loader
 ```
 
   </TabItem>


### PR DESCRIPTION
<!---
  Please do:
  - read CONTRIBUTING.md before sending a pull request
  - link issues that the PR is affecting (e.g #123)
  - try to make the test suite pass
  - add documentation
  - document potential tradeoffs in this PR.
-->

## How we got here?

Was just installing tailwindcss for a new project and noticed that the code block just next to the npm installs that I modified were importing `@remotion/bundler`, but installing the package was nowhere mentioned 🙃 Fixed that

In my previous PR, @JonnyBurger said that `css-loader` and `style-loader` packages are installed with `@remotion/bundler`, so feel free to edit this PR and remove those if needed!